### PR TITLE
Numbers converted to strings on updates

### DIFF
--- a/document.cfc
+++ b/document.cfc
@@ -475,9 +475,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 		
 		<cfset var result = ''>
 		
-		<cfinvoke component="json" method="encode" stringNumbers="true" data="#data#" returnvariable="result">
+		<cfset result = REReplace(SerializeJSON(arguments.data),'("[A-Z]*"[ ]?:)','\L\1','All')>
+        	<cfset result = REReplace(result,'("[A-Z]*[0-9]"[ ]?:)','\L\1','All')>
 		
-		<cfreturn result>
+		<cfreturn reReplace(result,'([_a-zA-Z]*)(":)','\L\1\2','ALL')>
 	</cffunction>
 	
 	
@@ -487,7 +488,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 		
 		<cfset var result = ''>
 		
-		<cfinvoke component="json" method="decode" data="#data#" returnvariable="result">
+		<cfset result = DeserializeJSON(arguments.data)>
 		
 		<cfreturn result>
 	</cffunction>


### PR DESCRIPTION
My numbers were being converted to strings when I updated documents. I updated the encodeJSON and decodeJSON methods within Document.cfc. JSON.cfc is no longer used. This fixes the issue and lowercases keys that are capitalized.

BTW, I've been using your CouchDB wrapper for almost a year. Thank you very much!
